### PR TITLE
fix: カートに追加ボタンの500エラー修正とフィードバック表示

### DIFF
--- a/app/Http/Controllers/CartController.php
+++ b/app/Http/Controllers/CartController.php
@@ -10,7 +10,7 @@ use App\Actions\UpdateCartItem;
 use App\Http\Requests\AddToCartRequest;
 use App\Http\Requests\UpdateCartItemRequest;
 use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
 use Inertia\Inertia;
 use Inertia\Response;
 use Lunar\Facades\CartSession;
@@ -65,30 +65,30 @@ final readonly class CartController
         ]);
     }
 
-    public function store(AddToCartRequest $request): JsonResponse
+    public function store(AddToCartRequest $request): RedirectResponse
     {
         $this->addToCart->handle(
             variantId: $request->integer('variantId'),
             quantity: $request->integer('quantity'),
         );
 
-        return response()->json(['message' => 'Added to cart']);
+        return back();
     }
 
-    public function update(UpdateCartItemRequest $request, int $cartLineId): JsonResponse
+    public function update(UpdateCartItemRequest $request, int $cartLineId): RedirectResponse
     {
         $this->updateCartItem->handle(
             cartLineId: $cartLineId,
             quantity: $request->integer('quantity'),
         );
 
-        return response()->json(['message' => 'Cart updated']);
+        return back();
     }
 
-    public function destroy(int $cartLineId): JsonResponse
+    public function destroy(int $cartLineId): RedirectResponse
     {
         $this->removeFromCart->handle(cartLineId: $cartLineId);
 
-        return response()->json(['message' => 'Item removed']);
+        return back();
     }
 }

--- a/config/lunar/cart.php
+++ b/config/lunar/cart.php
@@ -10,7 +10,6 @@ use Lunar\Actions\Carts\GetExistingCartLine;
 use Lunar\Actions\Carts\RemovePurchasable;
 use Lunar\Actions\Carts\SetShippingOption;
 use Lunar\Actions\Carts\UpdateCartLine;
-use Lunar\Pipelines\Cart\ApplyDiscounts;
 use Lunar\Pipelines\Cart\ApplyShipping;
 use Lunar\Pipelines\Cart\Calculate;
 use Lunar\Pipelines\Cart\CalculateLines;
@@ -66,7 +65,6 @@ return [
         'cart' => [
             CalculateLines::class,
             ApplyShipping::class,
-            ApplyDiscounts::class,
             CalculateTax::class,
             Calculate::class,
         ],

--- a/resources/js/pages/products/show.tsx
+++ b/resources/js/pages/products/show.tsx
@@ -203,23 +203,38 @@ export default function ProductsShow({ product }: Props) {
                     )}
 
                     {/* カートに追加ボタン */}
-                    <Form
-                        {...cartStore.form()}
-                        preserveScroll
-                    >
-                        <input
-                            type="hidden"
-                            name="variantId"
-                            value={selectedVariant?.id ?? ''}
-                        />
-                        <input type="hidden" name="quantity" value={1} />
-                        <button
-                            type="submit"
-                            disabled={!inStock || selectedVariant === null}
-                            className="w-full rounded-xl bg-gray-900 px-6 py-3 text-base font-semibold text-white transition-colors hover:bg-gray-700 disabled:cursor-not-allowed disabled:bg-gray-300 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100 dark:disabled:bg-neutral-700 dark:disabled:text-neutral-500"
-                        >
-                            {inStock ? 'カートに追加' : '在庫切れ'}
-                        </button>
+                    <Form {...cartStore.form()}>
+                        {({ processing, recentlySuccessful }) => (
+                            <>
+                                <input
+                                    type="hidden"
+                                    name="variantId"
+                                    value={selectedVariant?.id ?? ''}
+                                />
+                                <input
+                                    type="hidden"
+                                    name="quantity"
+                                    value={1}
+                                />
+                                <button
+                                    type="submit"
+                                    disabled={
+                                        processing ||
+                                        !inStock ||
+                                        selectedVariant === null
+                                    }
+                                    className="w-full rounded-xl bg-gray-900 px-6 py-3 text-base font-semibold text-white transition-colors hover:bg-gray-700 disabled:cursor-not-allowed disabled:bg-gray-300 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100 dark:disabled:bg-neutral-700 dark:disabled:text-neutral-500"
+                                >
+                                    {processing
+                                        ? '追加中...'
+                                        : recentlySuccessful
+                                          ? '✓ 追加しました'
+                                          : inStock
+                                            ? 'カートに追加'
+                                            : '在庫切れ'}
+                                </button>
+                            </>
+                        )}
                     </Form>
 
                     {/* 商品説明 */}

--- a/tests/Feature/Controllers/CartControllerTest.php
+++ b/tests/Feature/Controllers/CartControllerTest.php
@@ -81,12 +81,12 @@ it('カートが空の時、itemsが空配列であること', function (): void
 it('バリアントIDと数量を送信した時、カートにアイテムが追加されること', function (): void {
     $variant = createVariantWithPrice(price: 1500, stock: 10);
 
-    $response = $this->postJson(route('cart.items.store'), [
+    $response = $this->post(route('cart.items.store'), [
         'variantId' => $variant->id,
         'quantity' => 2,
     ]);
 
-    $response->assertOk();
+    $response->assertRedirect();
 
     $this->assertDatabaseHas('lunar_cart_lines', [
         'purchasable_type' => $variant->getMorphClass(),
@@ -98,8 +98,8 @@ it('バリアントIDと数量を送信した時、カートにアイテムが�
 it('同じバリアントを2回追加した時、数量が加算されること', function (): void {
     $variant = createVariantWithPrice(price: 1000, stock: 10);
 
-    $this->postJson(route('cart.items.store'), ['variantId' => $variant->id, 'quantity' => 1]);
-    $this->postJson(route('cart.items.store'), ['variantId' => $variant->id, 'quantity' => 2]);
+    $this->post(route('cart.items.store'), ['variantId' => $variant->id, 'quantity' => 1]);
+    $this->post(route('cart.items.store'), ['variantId' => $variant->id, 'quantity' => 2]);
 
     $this->assertDatabaseHas('lunar_cart_lines', [
         'purchasable_type' => $variant->getMorphClass(),
@@ -114,15 +114,15 @@ it('同じバリアントを2回追加した時、数量が加算されること
 it('カートラインIDと数量を送信した時、数量が更新されること', function (): void {
     $variant = createVariantWithPrice(price: 1000, stock: 10);
 
-    $this->postJson(route('cart.items.store'), ['variantId' => $variant->id, 'quantity' => 1]);
+    $this->post(route('cart.items.store'), ['variantId' => $variant->id, 'quantity' => 1]);
 
     $cartLine = CartLine::query()->where('purchasable_id', $variant->id)->firstOrFail();
 
-    $response = $this->patchJson(route('cart.items.update', $cartLine->id), [
+    $response = $this->patch(route('cart.items.update', $cartLine->id), [
         'quantity' => 5,
     ]);
 
-    $response->assertOk();
+    $response->assertRedirect();
 
     $this->assertDatabaseHas('lunar_cart_lines', [
         'id' => $cartLine->id,
@@ -135,13 +135,13 @@ it('カートラインIDと数量を送信した時、数量が更新される�
 it('カートラインIDを指定した時、アイテムが削除されること', function (): void {
     $variant = createVariantWithPrice(price: 1000, stock: 10);
 
-    $this->postJson(route('cart.items.store'), ['variantId' => $variant->id, 'quantity' => 1]);
+    $this->post(route('cart.items.store'), ['variantId' => $variant->id, 'quantity' => 1]);
 
     $cartLine = CartLine::query()->where('purchasable_id', $variant->id)->firstOrFail();
 
-    $response = $this->deleteJson(route('cart.items.destroy', $cartLine->id));
+    $response = $this->delete(route('cart.items.destroy', $cartLine->id));
 
-    $response->assertOk();
+    $response->assertRedirect();
 
     $this->assertDatabaseMissing('lunar_cart_lines', ['id' => $cartLine->id]);
 });
@@ -151,7 +151,7 @@ it('カートラインIDを指定した時、アイテムが削除されるこ�
 it('カートに追加後、GETでitemsに商品名・数量・小計が含まれること', function (): void {
     $variant = createVariantWithPrice(price: 2000, stock: 10);
 
-    $this->postJson(route('cart.items.store'), ['variantId' => $variant->id, 'quantity' => 2]);
+    $this->post(route('cart.items.store'), ['variantId' => $variant->id, 'quantity' => 2]);
 
     $response = $this->get(route('cart.index'));
 
@@ -170,7 +170,7 @@ it('カートに追加後、GETでitemsに商品名・数量・小計が含ま�
 it('カートに追加後、GETでtotalが含まれること', function (): void {
     $variant = createVariantWithPrice(price: 3000, stock: 10);
 
-    $this->postJson(route('cart.items.store'), ['variantId' => $variant->id, 'quantity' => 1]);
+    $this->post(route('cart.items.store'), ['variantId' => $variant->id, 'quantity' => 1]);
 
     $response = $this->get(route('cart.index'));
 


### PR DESCRIPTION
## Summary

- **500エラー修正**: LunarPHP の `ApplyDiscounts` パイプラインが `CarbonImmutable` 型を受け取れないバグにより、カート追加時に500エラーが発生していた。`config/lunar/cart.php` の pipeline から除外して回避
- **Inertia レスポンス修正**: `CartController` の `store/update/destroy` が `JsonResponse` を返していたため、Inertia が正しくページ更新できなかった。`back()` リダイレクトに変更
- **視覚的フィードバック追加**: `<Form>` レンダープロップの `processing` / `recentlySuccessful` を使い、ボタンに「追加中...」→「✓ 追加しました」の状態表示を追加

## Test plan

- [ ] `php artisan test --compact tests/Feature/Controllers/CartControllerTest.php` が全Pass
- [ ] 商品詳細ページで「カートに追加」を押すと500エラーが出ないこと
- [ ] ボタンが「追加中...」→「✓ 追加しました」→「カートに追加」と遷移すること
- [ ] ヘッダーのカート数が押す度に増えること

🤖 Generated with [Claude Code](https://claude.com/claude-code)