### PR TITLE
feat: レスポンシブ・ローディング・エラー表示・E2Eブラウザテストを実装 (#10)

### DIFF
--- a/resources/js/pages/cart/index.tsx
+++ b/resources/js/pages/cart/index.tsx
@@ -171,25 +171,27 @@ export default function CartIndex({
                             ) : (
                                 <Form {...cartApplyCoupon.form()}>
                                     {({ errors, processing }) => (
-                                        <div className="flex gap-2">
-                                            <input
-                                                type="text"
-                                                name="couponCode"
-                                                placeholder="クーポンコードを入力"
-                                                className="flex-1 rounded border border-gray-300 px-3 py-1.5 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none dark:border-neutral-700 dark:bg-neutral-900 dark:text-white"
-                                                aria-label="クーポンコード"
-                                            />
-                                            <button
-                                                type="submit"
-                                                disabled={processing}
-                                                className="rounded bg-gray-900 px-3 py-1.5 text-sm text-white transition-colors hover:bg-gray-700 disabled:opacity-50 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-200"
-                                            >
-                                                {processing
-                                                    ? '適用中...'
-                                                    : '適用'}
-                                            </button>
+                                        <div className="flex flex-col gap-1">
+                                            <div className="flex gap-2">
+                                                <input
+                                                    type="text"
+                                                    name="couponCode"
+                                                    placeholder="クーポンコードを入力"
+                                                    className="flex-1 rounded border border-gray-300 px-3 py-1.5 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none dark:border-neutral-700 dark:bg-neutral-900 dark:text-white"
+                                                    aria-label="クーポンコード"
+                                                />
+                                                <button
+                                                    type="submit"
+                                                    disabled={processing}
+                                                    className="rounded bg-gray-900 px-3 py-1.5 text-sm text-white transition-colors hover:bg-gray-700 disabled:opacity-50 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-200"
+                                                >
+                                                    {processing
+                                                        ? '適用中...'
+                                                        : '適用'}
+                                                </button>
+                                            </div>
                                             {errors.couponCode && (
-                                                <p className="mt-1 text-xs text-red-500">
+                                                <p className="text-xs text-red-500">
                                                     {errors.couponCode}
                                                 </p>
                                             )}

--- a/resources/js/pages/checkout/address.tsx
+++ b/resources/js/pages/checkout/address.tsx
@@ -1,7 +1,5 @@
-import {
-    shipping as checkoutShipping,
-    storeAddress,
-} from '@/actions/App/Http/Controllers/CheckoutController';
+import { index as cartIndex } from '@/actions/App/Http/Controllers/CartController';
+import { storeAddress } from '@/actions/App/Http/Controllers/CheckoutController';
 import StorefrontLayout from '@/layouts/storefront-layout';
 import { Form, Head, Link } from '@inertiajs/react';
 
@@ -159,7 +157,7 @@ export default function CheckoutAddress() {
 
                             <div className="flex items-center justify-between gap-4 pt-2">
                                 <Link
-                                    href={checkoutShipping.url()}
+                                    href={cartIndex.url()}
                                     className="text-sm text-gray-500 hover:text-gray-700 dark:text-neutral-400 dark:hover:text-neutral-200"
                                 >
                                     ← カートに戻る

--- a/tests/Browser/PurchaseFlowTest.php
+++ b/tests/Browser/PurchaseFlowTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Lunar\FieldTypes\Text;
+use Lunar\Models\Channel;
+use Lunar\Models\Country;
+use Lunar\Models\Currency;
+use Lunar\Models\Language;
+use Lunar\Models\Price;
+use Lunar\Models\Product;
+use Lunar\Models\ProductVariant;
+use Lunar\Models\TaxClass;
+use Lunar\Models\TaxRate;
+use Lunar\Models\TaxRateAmount;
+use Lunar\Models\TaxZone;
+use Lunar\Models\Url;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function (): void {
+    Language::factory()->create(['default' => true]);
+    Currency::factory()->create(['default' => true, 'code' => 'JPY']);
+    Channel::factory()->create(['default' => true]);
+    Country::factory()->create(['iso2' => 'JP', 'name' => 'Japan']);
+
+    $taxClass = TaxClass::factory()->create(['name' => 'Default']);
+    $taxZone = TaxZone::factory()->create(['default' => true]);
+    $taxRate = TaxRate::factory()->create(['tax_zone_id' => $taxZone->id]);
+    TaxRateAmount::factory()->create([
+        'tax_rate_id' => $taxRate->id,
+        'tax_class_id' => $taxClass->id,
+        'percentage' => 0,
+    ]);
+});
+
+it('商品一覧から注文完了まで全購買フローが動作すること', function (): void {
+    $currency = Currency::query()->where('default', true)->firstOrFail();
+    $taxClass = TaxClass::query()->where('name', 'Default')->firstOrFail();
+
+    $product = Product::factory()->create([
+        'status' => 'published',
+        'attribute_data' => collect([
+            'name' => new Text('E2Eテスト商品'),
+            'description' => new Text('テスト用の商品です'),
+        ]),
+    ]);
+
+    Url::factory()->create([
+        'language_id' => Language::query()->where('default', true)->value('id'),
+        'element_type' => Product::morphName(),
+        'element_id' => $product->id,
+        'slug' => 'e2e-test-product',
+        'default' => true,
+    ]);
+
+    $variant = ProductVariant::factory()->create([
+        'product_id' => $product->id,
+        'tax_class_id' => $taxClass->id,
+        'stock' => 10,
+        'purchasable' => 'in_stock',
+    ]);
+
+    Price::query()->create([
+        'currency_id' => $currency->id,
+        'priceable_type' => $variant->getMorphClass(),
+        'priceable_id' => $variant->id,
+        'price' => 2000,
+        'min_quantity' => 1,
+    ]);
+
+    $page = visit('/products');
+
+    $page->assertSee('E2Eテスト商品')
+        ->click('E2Eテスト商品')
+        ->assertSee('E2Eテスト商品')
+        ->assertSee('カートに追加')
+        ->click('カートに追加')
+        ->navigate('/cart')
+        ->assertSee('E2Eテスト商品')
+        ->assertSee('レジに進む')
+        ->click('レジに進む')
+        ->fill('input[name="first_name"]', '山田太郎')
+        ->fill('input[name="postcode"]', '100-0001')
+        ->fill('input[name="state"]', '東京都')
+        ->fill('input[name="city"]', '千代田区')
+        ->fill('input[name="line_one"]', '千代田1-1-1')
+        ->fill('input[name="contact_phone"]', '03-1234-5678')
+        ->click('button[type="submit"]')
+        ->assertSee('配送方法を選択')
+        ->click('input[value="flat_rate_standard"]')
+        ->click('button[type="submit"]')
+        ->assertSee('注文内容の確認')
+        ->click('button[type="submit"]')
+        ->assertSee('ご注文ありがとうございます')
+        ->assertSee('注文番号')
+        ->assertNoJavascriptErrors();
+});

--- a/tests/Browser/SmokeTest.php
+++ b/tests/Browser/SmokeTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Lunar\Models\Language;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function (): void {
+    Language::factory()->create(['default' => true]);
+});
+
+it('全ストアフロントページでJavaScriptエラーが発生しないこと', function (): void {
+    $pages = visit(['/products', '/cart']);
+
+    $pages->assertNoSmoke();
+});

--- a/tests/TESTS.md
+++ b/tests/TESTS.md
@@ -5,6 +5,12 @@
 ### WelcomeTest
 - [ ] has welcome page
 
+### SmokeTest
+- [ ] 全ストアフロントページでJavaScriptエラーが発生しないこと
+
+### PurchaseFlowTest
+- [ ] 商品一覧から注文完了まで全購買フローが動作すること
+
 ### CartPageTest
 - [ ] カートページが正しく表示されること
 - [ ] カートが空の時に空メッセージが表示されること

--- a/tests/TESTS_TREE.md
+++ b/tests/TESTS_TREE.md
@@ -5,6 +5,10 @@ tests/
 ├── Browser/
 │   ├── WelcomeTest
 │   │   └── has welcome page
+│   ├── SmokeTest
+│   │   └── 全ストアフロントページでJavaScriptエラーが発生しないこと
+│   ├── PurchaseFlowTest
+│   │   └── 商品一覧から注文完了まで全購買フローが動作すること
 │   ├── CartPageTest
 │   │   ├── カートページが正しく表示されること
 │   │   ├── カートが空の時に空メッセージが表示されること


### PR DESCRIPTION
## Summary

- 全ストアフロントページ（`/products`, `/cart`）のスモークテストを追加
- 商品一覧→商品詳細→カート追加→チェックアウト→注文完了の全購買フローE2Eブラウザテストを追加
- カートクーポンエラーメッセージが `flex` 横並びになるレイアウトバグを修正
- チェックアウト住所ページの「← カートに戻る」リンクが `/checkout/shipping` を誤って指していたバグを修正

## Test plan

- [x] `tests/Browser/SmokeTest.php` — `/products` と `/cart` で JS エラーなし
- [x] `tests/Browser/PurchaseFlowTest.php` — 全購買フロー（10アサーション）
- [x] `php artisan test --compact tests/Browser/` — 19テスト全通過
- [x] `php artisan test --compact tests/Feature tests/Unit` — 234テスト全通過
- [x] `vendor/bin/pint --dirty` — コードスタイル通過

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)