### PR TITLE
fix: activity_logのcauser_idをvarcharに変更してUUID対応

### DIFF
--- a/database/migrations/2026_03_26_121944_change_causer_id_to_string_in_activity_log.php
+++ b/database/migrations/2026_03_26_121944_change_causer_id_to_string_in_activity_log.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('activity_log', function (Blueprint $table): void {
+            $table->string('causer_id', 100)->nullable()->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('activity_log', function (Blueprint $table): void {
+            $table->unsignedBigInteger('causer_id')->nullable()->change();
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- `activity_log.causer_id` カラムを `bigint` から `varchar(100)` に変更
- UserモデルがUUIDを主キーとして使用しているため、カートへの商品追加時にアクティビティログの書き込みで `Data truncated for column 'causer_id'` エラーが発生していた

## Test plan
- [ ] カートに商品を追加してエラーが発生しないことを確認
- [ ] `php artisan migrate` が正常に実行できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)